### PR TITLE
ported the arduino code to micropython for Raspberry Pi Pico

### DIFF
--- a/boxctrl_6d0f_imu.py
+++ b/boxctrl_6d0f_imu.py
@@ -5,9 +5,9 @@ from OpenGL.GLU import *
 import pygame
 from pygame.locals import *
 import serial
-
+ser = serial.Serial('/dev/ttyACM0', 38400, timeout=1)  #for pico
 #ser = serial.Serial('/dev/tty.usbserial', 38400, timeout=1)
-ser = serial.Serial('COM3', 38400, timeout=1)
+#ser = serial.Serial('COM3', 38400, timeout=1)
 
 ax = ay = az = 0.0
 yaw_mode = False

--- a/rpipico_micropython/PiicoDev_MPU6050.py
+++ b/rpipico_micropython/PiicoDev_MPU6050.py
@@ -1,0 +1,228 @@
+# Class to read data from the Core Electronics PiicoDev Motion Sensor MPU-6050
+# Ported to MicroPython by Peter Johnston and Michael Ruppeat Core Electronics APR 2021
+# Original repo https://github.com/nickcoutsos/MPU-6050-Python
+
+from PiicoDev_Unified import *
+from math import sqrt, atan2
+
+compat_str = '\nUnified PiicoDev library out of date.  Get the latest module: https://piico.dev/unified \n'
+
+# Global Variables
+_GRAVITIY_MS2 = 9.80665
+
+# Scale Modifiers
+_ACC_SCLR_2G = 16384.0
+_ACC_SCLR_4G = 8192.0
+_ACC_SCLR_8G = 4096.0
+_ACC_SCLR_16G = 2048.0
+
+_GYR_SCLR_250DEG = 131.0
+_GYR_SCLR_500DEG = 65.5
+_GYR_SCLR_1000DEG = 32.8
+_GYR_SCLR_2000DEG = 16.4
+
+# Pre-defined ranges
+_ACC_RNG_2G = 0x00
+_ACC_RNG_4G = 0x08
+_ACC_RNG_8G = 0x10
+_ACC_RNG_16G = 0x18
+
+_GYR_RNG_250DEG = 0x00
+_GYR_RNG_500DEG = 0x08
+_GYR_RNG_1000DEG = 0x10
+_GYR_RNG_2000DEG = 0x18
+
+# MPU-6050 Registers
+_PWR_MGMT_1 = 0x6B
+
+_ACCEL_XOUT0 = 0x3B
+
+_TEMP_OUT0 = 0x41
+
+_GYRO_XOUT0 = 0x43
+
+_ACCEL_CONFIG = 0x1C
+_GYRO_CONFIG = 0x1B
+
+_maxFails = 3
+
+# Address
+_MPU6050_ADDRESS = 0x68
+
+def signedIntFromBytes(x, endian='big'):
+    y = int.from_bytes(x, endian)
+    if (y >= 0x8000):
+        return -((65535 - y) + 1)
+    else:
+        return y
+    
+
+class PiicoDev_MPU6050(object):     
+    def __init__(self, bus=None, freq=None, sda=None, scl=None, addr=_MPU6050_ADDRESS):
+        self._failCount = 0
+        self._terminatingFailCount = 0
+        try:
+            if compat_ind >= 1:
+                pass
+            else:
+                print(compat_str)
+        except:
+            print(compat_str)
+        self.i2c = create_unified_i2c(bus=bus, freq=freq, sda=sda, scl=scl)
+        self.addr = addr
+        try:
+            # Wake up the MPU-6050 since it starts in sleep mode
+            self.i2c.writeto_mem(self.addr, _PWR_MGMT_1, bytes([0x00]))
+            sleep_ms(5)
+        except Exception as e:
+            print(i2c_err_str.format(self.addr))
+            raise e
+        self._accel_range = self.get_accel_range(True)
+        self._gyro_range = self.get_gyro_range(True)
+
+    def _readData(self, register):
+        failCount = 0
+        while failCount < _maxFails:
+            try:
+                sleep_ms(10)
+                data = self.i2c.readfrom_mem(self.addr, register, 6)
+                break
+            except:
+                failCount = failCount + 1
+                self._failCount = self._failCount + 1
+                if failCount >= _maxFails:
+                    self._terminatingFailCount = self._terminatingFailCount + 1
+                    print(i2c_err_str.format(self.addr))
+                    return {'x': float('NaN'), 'y': float('NaN'), 'z': float('NaN')} 
+        x = signedIntFromBytes(data[0:2])
+        y = signedIntFromBytes(data[2:4])
+        z = signedIntFromBytes(data[4:6])
+        return {'x': x, 'y': y, 'z': z}
+
+    # Reads the temperature from the onboard temperature sensor of the MPU-6050.
+    # Returns the temperature [degC].
+    def read_temperature(self):
+        try:
+            rawData = self.i2c.readfrom_mem(self.addr, _TEMP_OUT0, 2)
+            raw_temp = (signedIntFromBytes(rawData, 'big'))
+        except:
+            print(i2c_err_str.format(self.addr))
+            return float('NaN')
+        actual_temp = (raw_temp / 340) + 36.53
+        return actual_temp
+
+    # Sets the range of the accelerometer
+    # accel_range : the range to set the accelerometer to. Using a pre-defined range is advised.
+    def set_accel_range(self, accel_range):
+        self.i2c.writeto_mem(self.addr, _ACCEL_CONFIG, bytes([accel_range]))
+        self._accel_range = accel_range
+
+    # Gets the range the accelerometer is set to.
+    # raw=True: Returns raw value from the ACCEL_CONFIG register
+    # raw=False: Return integer: -1, 2, 4, 8 or 16. When it returns -1 something went wrong.
+    def get_accel_range(self, raw = False):
+        # Get the raw value
+        raw_data = self.i2c.readfrom_mem(self.addr, _ACCEL_CONFIG, 2)
+        
+        if raw is True:
+            return raw_data[0]
+        elif raw is False:
+            if raw_data[0] == _ACC_RNG_2G:
+                return 2
+            elif raw_data[0] == _ACC_RNG_4G:
+                return 4
+            elif raw_data[0] == _ACC_RNG_8G:
+                return 8
+            elif raw_data[0] == _ACC_RNG_16G:
+                return 16
+            else:
+                return -1
+
+    # Reads and returns the X, Y and Z values from the accelerometer.
+    # Returns dictionary data in g or m/s^2 (g=False)
+    def read_accel_data(self, g = False):         
+        accel_data = self._readData(_ACCEL_XOUT0)
+        accel_range = self._accel_range
+        scaler = None
+        if accel_range == _ACC_RNG_2G:
+            scaler = _ACC_SCLR_2G
+        elif accel_range == _ACC_RNG_4G:
+            scaler = _ACC_SCLR_4G
+        elif accel_range == _ACC_RNG_8G:
+            scaler = _ACC_SCLR_8G
+        elif accel_range == _ACC_RNG_16G:
+            scaler = _ACC_SCLR_16G
+        else:
+            print("Unkown range - scaler set to _ACC_SCLR_2G")
+            scaler = _ACC_SCLR_2G
+
+        x = accel_data['x'] / scaler
+        y = accel_data['y'] / scaler
+        z = accel_data['z'] / scaler
+
+        if g is True:
+            return {'x': x, 'y': y, 'z': z}
+        elif g is False:
+            x = x * _GRAVITIY_MS2
+            y = y * _GRAVITIY_MS2
+            z = z * _GRAVITIY_MS2
+            return {'x': x, 'y': y, 'z': z}
+
+    def read_accel_abs(self, g=False):
+        d=self.read_accel_data(g)
+        return sqrt(d['x']**2+d['y']**2+d['z']**2)
+
+    def set_gyro_range(self, gyro_range):
+        self.i2c.writeto_mem(self.addr, _GYRO_CONFIG, bytes([gyro_range]))
+        self._gyro_range = gyro_range
+
+    # Gets the range the gyroscope is set to.
+    # raw=True: return raw value from GYRO_CONFIG register
+    # raw=False: return range in deg/s
+    def get_gyro_range(self, raw = False):
+        # Get the raw value
+        raw_data = self.i2c.readfrom_mem(self.addr, _GYRO_CONFIG, 2)
+
+        if raw is True:
+            return raw_data[0]
+        elif raw is False:
+            if raw_data[0] == _GYR_RNG_250DEG:
+                return 250
+            elif raw_data[0] == _GYR_RNG_500DEG:
+                return 500
+            elif raw_data[0] == _GYR_RNG_1000DEG:
+                return 1000
+            elif raw_data[0] == _GYR_RNG_2000DEG:
+                return 2000
+            else:
+                return -1
+
+    # Gets and returns the X, Y and Z values from the gyroscope.
+    # Returns the read values in a dictionary.
+    def read_gyro_data(self):
+        gyro_data = self._readData(_GYRO_XOUT0)
+        gyro_range = self._gyro_range
+        scaler = None
+        if gyro_range == _GYR_RNG_250DEG:
+            scaler = _GYR_SCLR_250DEG
+        elif gyro_range == _GYR_RNG_500DEG:
+            scaler = _GYR_SCLR_500DEG
+        elif gyro_range == _GYR_RNG_1000DEG:
+            scaler = _GYR_SCLR_1000DEG
+        elif gyro_range == _GYR_RNG_2000DEG:
+            scaler = _GYR_SCLR_2000DEG
+        else:
+            print("Unkown range - scaler set to _GYR_SCLR_250DEG")
+            scaler = _GYR_SCLR_250DEG
+
+        x = gyro_data['x'] / scaler
+        y = gyro_data['y'] / scaler
+        z = gyro_data['z'] / scaler
+
+        return {'x': x, 'y': y, 'z': z}
+
+    def read_angle(self): # returns radians. orientation matches silkscreen
+        a=self.read_accel_data()
+        x=atan2(a['y'],a['z'])
+        y=atan2(-a['x'],a['z'])
+        return {'x': x, 'y': y}

--- a/rpipico_micropython/PiicoDev_Unified.py
+++ b/rpipico_micropython/PiicoDev_Unified.py
@@ -1,0 +1,190 @@
+'''
+PiicoDev.py: Unifies I2C drivers for different builds of MicroPython
+Changelog:
+    - 2021       M.Ruppe - Initial Unified Driver
+    - 2022-10-13 P.Johnston - Add helptext to run i2csetup script on Raspberry Pi 
+    - 2022-10-14 M.Ruppe - Explicitly set default I2C initialisation parameters for machine-class (Raspberry Pi Pico + W)
+    - 2023-01-31 L.Howell - Add minimal support for ESP32
+    - 2023-05-17 M.Ruppe - Make I2CUnifiedMachine() more flexible on initialisation. Frequency is optional.
+    - 2023-12-20 M.Taylor - added scan() function for quick userland test of connected i2c modules
+'''
+import os
+_SYSNAME = os.uname().sysname
+compat_ind = 1
+i2c_err_str = 'PiicoDev could not communicate with module at address 0x{:02X}, check wiring'
+setupi2c_str = ', run "sudo curl -L https://piico.dev/i2csetup | bash". Suppress this warning by setting suppress_warnings=True'
+
+if _SYSNAME == 'microbit':
+    from microbit import i2c
+    from utime import sleep_ms
+    
+elif _SYSNAME == 'Linux':
+    from smbus2 import SMBus, i2c_msg
+    from time import sleep
+    from math import ceil
+    
+    def sleep_ms(t):
+        sleep(t/1000)
+
+else:
+    from machine import I2C, Pin
+    from utime import sleep_ms
+
+class I2CBase:
+    def writeto_mem(self, addr, memaddr, buf, *, addrsize=8):
+        raise NotImplementedError('writeto_mem')
+
+    def readfrom_mem(self, addr, memaddr, nbytes, *, addrsize=8):
+        raise NotImplementedError('readfrom_mem')
+
+    def write8(self, addr, buf, stop=True):
+        raise NotImplementedError('write')
+
+    def read16(self, addr, nbytes, stop=True):
+        raise NotImplementedError('read')
+
+    def __init__(self, bus=None, freq=None, sda=None, scl=None):
+        raise NotImplementedError('__init__')
+
+class I2CUnifiedMachine(I2CBase):
+    def __init__(self, bus=None, freq=None, sda=None, scl=None):
+        if _SYSNAME == 'esp32' and (bus is None or sda is None or scl is None):
+            raise Exception('Please input bus, machine.pin SDA, and SCL objects to use ESP32')
+        
+        if freq is None: freq = 400_000
+        if not isinstance(freq, (int)):
+            raise ValueError("freq must be an Int")
+        if freq < 400_000: print("\033[91mWarning: minimum freq 400kHz is recommended if using OLED module.\033[0m")
+        if bus is not None and sda is not None and scl is not None:
+            print('Using supplied bus, sda, and scl to create machine.I2C() with freq: {} Hz'.format(freq))
+            self.i2c = I2C(bus, freq=freq, sda=sda, scl=scl)
+        elif bus is None and sda is None and scl is None:
+            self.i2c = I2C(0, scl=Pin(9), sda=Pin(8), freq=freq) # RPi Pico in Expansion Board
+        else:
+            raise Exception("Please provide at least bus, sda, and scl")
+
+        self.writeto_mem = self.i2c.writeto_mem
+        self.readfrom_mem = self.i2c.readfrom_mem
+
+    def write8(self, addr, reg, data):
+        if reg is None:
+            self.i2c.writeto(addr, data)
+        else:
+            self.i2c.writeto(addr, reg + data)
+            
+    def read16(self, addr, reg):
+        self.i2c.writeto(addr, reg, False)
+        return self.i2c.readfrom(addr, 2)
+        
+    def scan(self):
+        print([hex(i) for i in self.i2c.scan()])
+
+class I2CUnifiedMicroBit(I2CBase):
+    def __init__(self, freq=None):
+        if freq is not None:
+            print('Initialising I2C freq to {}'.format(freq))
+            microbit.i2c.init(freq=freq)
+            
+    def writeto_mem(self, addr, memaddr, buf, *, addrsize=8):
+        ad = memaddr.to_bytes(addrsize // 8, 'big')  # pad address for eg. 16 bit
+        i2c.write(addr, ad + buf)
+        
+    def readfrom_mem(self, addr, memaddr, nbytes, *, addrsize=8):
+        ad = memaddr.to_bytes(addrsize // 8, 'big')  # pad address for eg. 16 bit
+        i2c.write(addr, ad, repeat=True)
+        return i2c.read(addr, nbytes)    
+    
+    def write8(self, addr, reg, data):
+        if reg is None:
+            i2c.write(addr, data)
+        else:
+            i2c.write(addr, reg + data)
+
+    def read16(self, addr, reg):
+        i2c.write(addr, reg, repeat=True)
+        return i2c.read(addr, 2)
+            
+    def scan(self):
+        print([hex(i) for i in self.i2c.scan()])
+
+class I2CUnifiedLinux(I2CBase):
+    def __init__(self, bus=None, suppress_warnings=True):
+        if suppress_warnings == False:
+            with open('/boot/config.txt') as config_file:
+                if 'dtparam=i2c_arm=on' in config_file.read():
+                    pass
+                else:
+                    print('I2C is not enabled. To enable' + setupi2c_str)
+                config_file.close()
+            with open('/boot/config.txt') as config_file:
+                if 'dtparam=i2c_arm_baudrate=400000' in config_file.read():
+                    pass
+                else:
+                    print('Slow baudrate detected. If glitching occurs' + setupi2c_str)
+                config_file.close()
+        if bus is None:
+            bus = 1
+        self.i2c = SMBus(bus)
+
+    def readfrom_mem(self, addr, memaddr, nbytes, *, addrsize=8):
+        data = [None] * nbytes # initialise empty list
+        self.smbus_i2c_read(addr, memaddr, data, nbytes, addrsize=addrsize)
+        return data
+    
+    def writeto_mem(self, addr, memaddr, buf, *, addrsize=8):
+        self.smbus_i2c_write(addr, memaddr, buf, len(buf), addrsize=addrsize)
+    
+    def smbus_i2c_write(self, address, reg, data_p, length, addrsize=8):
+        ret_val = 0
+        data = []
+        for index in range(length):
+            data.append(data_p[index])
+        if addrsize == 8:
+            msg_w = i2c_msg.write(address, [reg] + data)
+        elif addrsize == 16:
+            msg_w = i2c_msg.write(address, [reg >> 8, reg & 0xff] + data)
+        else:
+            raise Exception('address must be 8 or 16 bits long only')
+        self.i2c.i2c_rdwr(msg_w)
+        return ret_val
+        
+    def smbus_i2c_read(self, address, reg, data_p, length, addrsize=8):
+        ret_val = 0
+        if addrsize == 8:
+            msg_w = i2c_msg.write(address, [reg]) # warning this is set up for 16-bit addresses
+        elif addrsize == 16:
+            msg_w = i2c_msg.write(address, [reg >> 8, reg & 0xff]) # warning this is set up for 16-bit addresses
+        else:
+            raise Exception('address must be 8 or 16 bits long only')
+        msg_r = i2c_msg.read(address, length)
+        self.i2c.i2c_rdwr(msg_w, msg_r)
+        if ret_val == 0:
+            for index in range(length):
+                data_p[index] = ord(msg_r.buf[index])
+        return ret_val
+    
+    def write8(self, addr, reg, data):
+        if reg is None:
+            d = int.from_bytes(data, 'big')
+            self.i2c.write_byte(addr, d)
+        else:
+            r = int.from_bytes(reg, 'big')
+            d = int.from_bytes(data, 'big')
+            self.i2c.write_byte_data(addr, r, d)
+    
+    def read16(self, addr, reg):
+        regInt = int.from_bytes(reg, 'big')
+        return self.i2c.read_word_data(addr, regInt).to_bytes(2, byteorder='little', signed=False)
+
+    def scan(self):
+        print([hex(i) for i in self.i2c.scan()])
+
+
+def create_unified_i2c(bus=None, freq=None, sda=None, scl=None, suppress_warnings=True):
+    if _SYSNAME == 'microbit':
+        i2c = I2CUnifiedMicroBit(freq=freq)
+    elif _SYSNAME == 'Linux':
+        i2c = I2CUnifiedLinux(bus=bus, suppress_warnings=suppress_warnings)
+    else:
+        i2c = I2CUnifiedMachine(bus=bus, freq=freq, sda=sda, scl=scl)
+    return i2c

--- a/rpipico_micropython/main.py
+++ b/rpipico_micropython/main.py
@@ -1,0 +1,70 @@
+import math
+from PiicoDev_MPU6050 import PiicoDev_MPU6050
+import time
+import sys
+import uselect
+
+# Initialize MPU6050 (bus=1, sda=14, scl=15)
+mpu = PiicoDev_MPU6050(bus=1, sda=14, scl=15)
+
+# Calibrate gyro to calculate offsets in deg/s
+def calibrate_gyro(num_samples=500):
+    gx_total = gy_total = gz_total = 0.0
+    for _ in range(num_samples):
+        gyro = mpu.read_gyro_data()
+        gx_total += gyro['x']
+        gy_total += gyro['y']
+        gz_total += gyro['z']
+        time.sleep_ms(1)
+    return (gx_total/num_samples, gy_total/num_samples, gz_total/num_samples)
+
+gyrX_offset, gyrY_offset, gyrZ_offset = calibrate_gyro()
+
+# Complementary filter variables
+gx = gy = gz = 0.0
+FREQ = 30.0
+dt = 1.0 / FREQ
+
+# Setup non-blocking input for serial requests
+poll = uselect.poll()
+poll.register(sys.stdin, uselect.POLLIN)
+
+while True:
+    start_time = time.ticks_ms()
+    
+    # Read accelerometer and calculate angles
+    accel = mpu.read_accel_data(g=True)
+    ax, ay, az = accel['x'], accel['y'], accel['z']
+    
+    roll_acc = math.degrees(math.atan2(ay, math.sqrt(ax**2 + az**2)))
+    pitch_acc = math.degrees(math.atan2(ax, math.sqrt(ay**2 + az**2)))
+    
+    # Read and calibrate gyro data (deg/s)
+    gyro = mpu.read_gyro_data()
+    gyrX = gyro['x'] - gyrX_offset
+    gyrY = -(gyro['y'] - gyrY_offset)  # Negative sign to match Arduino orientation
+    gyrZ = gyro['z'] - gyrZ_offset
+    
+    # Integrate gyro data
+    gx += gyrX * dt
+    gy += gyrY * dt
+    gz += gyrZ * dt
+    
+    # Apply complementary filter (96% gyro, 4% accelerometer)
+    alpha = 0.96
+    gx = gx * alpha + roll_acc * (1 - alpha)
+    gy = gy * alpha + pitch_acc * (1 - alpha)
+    
+    # Check for incoming serial commands
+    if poll.poll(0):
+        cmd = sys.stdin.read(1)
+        if cmd == '.':
+            print("{:.2f}, {:.2f}, {:.2f}".format(gx, gy, gz))
+        elif cmd == 'z':
+            gz = 0  # Reset yaw
+    
+    # Maintain sample rate
+    elapsed = time.ticks_diff(time.ticks_ms(), start_time)
+    remaining = int(1000/FREQ) - elapsed
+    if remaining > 0:
+        time.sleep_ms(remaining)


### PR DESCRIPTION
This PR adds MicroPython support for the Raspberry Pi Pico by porting the original Arduino-based MPU6050 code. The new implementation allows the sensor data to be used in the same way as the original.

**Changes:**

- Ported the Arduino code to MicroPython for compatibility with the Raspberry Pi Pico.
- Used [CE-PiicoDev-MPU6050-MicroPython-Module](https://github.com/CoreElectronics/CE-PiicoDev-MPU6050-MicroPython-Module) and [CE-PiicoDev-Unified](https://github.com/CoreElectronics/CE-PiicoDev-Unified) to interface with the MPU6050.
- Updated the Python visualization code to include the Pico's default serial port.